### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,7 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "": {
+    "dependencies": {
       "name": "katatak-be",
       "version": "1.0.0",
       "license": "ISC",


### PR DESCRIPTION
ts-built bug is persisting, package lock seems to be missing 'dependency' word so adding this.